### PR TITLE
Improved elmah logger

### DIFF
--- a/src/ServiceStack.Logging.Elmah/ElmahInterceptingLogger.cs
+++ b/src/ServiceStack.Logging.Elmah/ElmahInterceptingLogger.cs
@@ -6,23 +6,10 @@ namespace ServiceStack.Logging.Elmah
 {
 	/// <summary>	Writes Elmah intercepting logger.  </summary>
 	/// <remarks>	9/2/2011. </remarks>
-	public class ElmahInterceptingLogger 
+	public class ElmahInterceptingLogger
 		: ILog
 	{
-		private readonly ILog _log;
-		private readonly ErrorLog _errorLog;
-
-		/// <summary>	Constructor. </summary>
-		/// <remarks>
-		/// Logs to Elmahs ErrorLog.GetDefault.  Only Error and Fatal are passed along to Elmah, while all other errors will be written to the
-		/// wrapped logger.
-		/// </remarks>
-		/// <param name="log">	The underlying log to write to. </param>
-		///
-		/// <exception cref="ArgumentNullException">	Thrown when the wrapped log is null. </exception>
-		public ElmahInterceptingLogger(ILog log)
-			: this(log, ErrorLog.GetDefault(HttpContext.Current))
-		{ }
+		private readonly ILog log;
 
 		/// <summary>	Constructor. </summary>
 		/// <remarks>
@@ -32,99 +19,97 @@ namespace ServiceStack.Logging.Elmah
 		/// <exception cref="ArgumentNullException">	Thrown when either the wrapped ILog or Elmah ErrorLog are null. </exception>
 		/// <param name="log">	   	The underlying log to write to. </param>
 		/// <param name="errorLog">	The error log. </param>
-		public ElmahInterceptingLogger(ILog log, ErrorLog errorLog)
+		public ElmahInterceptingLogger(ILog log)
 		{
 			if (null == log) { throw new ArgumentNullException("log"); }
-			if (null == errorLog) { throw new ArgumentNullException("errorLog"); }
 
-			_log = log;
-			_errorLog = errorLog;
+			this.log = log;
 		}
 
 		public void Debug(object message, Exception exception)
 		{
-			_log.Debug(message, exception);
+			log.Debug(message, exception);
 		}
 
 		public void Debug(object message)
 		{
-			_log.Debug(message);
+			log.Debug(message);
 		}
 
 		public void DebugFormat(string format, params object[] args)
 		{
-			_log.DebugFormat(format, args);
+			log.DebugFormat(format, args);
 		}
 
 		public void Error(object message, Exception exception)
 		{
-			_errorLog.Log(new Error(exception, HttpContext.Current));
-			_log.Error(message, exception);
+			ErrorLog.GetDefault(HttpContext.Current).Log(new Error(exception, HttpContext.Current));
+			log.Error(message, exception);
 		}
 
 		public void Error(object message)
 		{
-			_errorLog.Log(new Error(new System.ApplicationException(message.ToString()), HttpContext.Current));
-			_log.Error(message);
+			ErrorLog.GetDefault(HttpContext.Current).Log(new Error(new System.ApplicationException(message.ToString()), HttpContext.Current));
+			log.Error(message);
 		}
 
 		public void ErrorFormat(string format, params object[] args)
 		{
-			_errorLog.Log(new Error(new System.ApplicationException(string.Format(format, args)), HttpContext.Current));
-			_log.ErrorFormat(format, args);
+			ErrorLog.GetDefault(HttpContext.Current).Log(new Error(new System.ApplicationException(string.Format(format, args)), HttpContext.Current));
+			log.ErrorFormat(format, args);
 		}
 
 		public void Fatal(object message, Exception exception)
 		{
-			_errorLog.Log(new Error(exception, HttpContext.Current));
-			_log.Fatal(message, exception);
+			ErrorLog.GetDefault(HttpContext.Current).Log(new Error(exception, HttpContext.Current));
+			log.Fatal(message, exception);
 		}
 
 		public void Fatal(object message)
 		{
-			_errorLog.Log(new Error(new System.ApplicationException(message.ToString()), HttpContext.Current));
-			_log.Fatal(message);
+			ErrorLog.GetDefault(HttpContext.Current).Log(new Error(new System.ApplicationException(message.ToString()), HttpContext.Current));
+			log.Fatal(message);
 		}
 
 		public void FatalFormat(string format, params object[] args)
 		{
-			_errorLog.Log(new Error(new System.ApplicationException(string.Format(format, args)), HttpContext.Current));
-			_log.FatalFormat(format, args);
+			ErrorLog.GetDefault(HttpContext.Current).Log(new Error(new System.ApplicationException(string.Format(format, args)), HttpContext.Current));
+			log.FatalFormat(format, args);
 		}
 
 		public void Info(object message, Exception exception)
 		{
-			_log.Info(message, exception);
+			log.Info(message, exception);
 		}
 
 		public void Info(object message)
 		{
-			_log.Info(message);
+			log.Info(message);
 		}
 
 		public void InfoFormat(string format, params object[] args)
 		{
-			_log.InfoFormat(format, args);
+			log.InfoFormat(format, args);
 		}
 
 		public bool IsDebugEnabled
 		{
-			get { return _log.IsDebugEnabled; }
+			get { return log.IsDebugEnabled; }
 		}
 
 		public void Warn(object message, Exception exception)
 		{
-			_log.Warn(message, exception);
+			log.Warn(message, exception);
 		}
 
 		public void Warn(object message)
 		{
-			_log.Warn(message);
+			log.Warn(message);
 		}
 
 		public void WarnFormat(string format, params object[] args)
 		{
-			_log.WarnFormat(format, args);
+			log.WarnFormat(format, args);
 		}
 	}
 }


### PR DESCRIPTION
The old elmah logger was throwing an exception on startup, because the HttpContext isn't available on startup.

```
Request is not available in this context
   at System.Web.HttpContext.get_Request()
   at Elmah.ErrorLog.InferApplicationName(HttpContext context)
   at Elmah.ErrorLog.GetDefaultImpl(HttpContext context)
   at Elmah.ServiceContainer.GetService(Type serviceType)
   at Elmah.ServiceCenter.FindService(Object context, Type serviceType)
   at Elmah.ServiceCenter.GetService(Object context, Type serviceType)
   at Elmah.ErrorLog.GetDefault(HttpContext context)
   at ServiceStack.Logging.Elmah.ElmahLogFactory.GetLogger(Type type)
   at ServiceStack.Logging.LogManager.GetLogger(Type type) in C:\src\ServiceStack\src\ServiceStack.Interfaces\Logging\LogManager.cs:line 39
   at ServiceStack.WebHost.EndPoints.Formats.MarkdownFormat..cctor()
```
