### PR TITLE
Fix Log4Netv1210 log4net references to correct dll versions

### DIFF
--- a/src/ServiceStack.Logging.Log4Netv1210/ServiceStack.Logging.Log4Netv1210.csproj
+++ b/src/ServiceStack.Logging.Log4Netv1210/ServiceStack.Logging.Log4Netv1210.csproj
@@ -63,7 +63,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">
-      <HintPath>..\packages\log4net.2.0.0\lib\net35-full\log4net.dll</HintPath>
+      <HintPath>..\..\lib\log4net.1.2.10.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Common, Version=3.9.32.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/ServiceStack.Logging.Log4Netv1210/packages.config
+++ b/src/ServiceStack.Logging.Log4Netv1210/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.0" targetFramework="net35" />
   <package id="ServiceStack.Common" version="3.9.32" targetFramework="net35" />
   <package id="ServiceStack.Text" version="3.9.32" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
Commit a652fcaacc broke references in `ServiceStack.Logging.Log4Netv1210`.

I have updated `ServiceStack.Logging.Log4Netv1210` to match `ServiceStack.Logging.Log4Netv129`:
- removed log4net from project nuget packages.config
- replaced reference in .csproj to point to libs version of log4net
- fixed reference in .csproj to point to the correct verion of log4net (`lib\log4net.1.2.10.dll`)
