### PR TITLE
Tweaks to NLog logger

### DIFF
--- a/src/ServiceStack.Logging.NLog/NLogFactory.cs
+++ b/src/ServiceStack.Logging.NLog/NLogFactory.cs
@@ -6,7 +6,7 @@ namespace ServiceStack.Logging.NLogger
     /// <summary>
     /// ILogFactory that creates an NLog ILog logger
     /// </summary>
-	public class NLogFactory : ServiceStack.Logging.ILogFactory
+    public class NLogFactory : ServiceStack.Logging.ILogFactory
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NLogFactory"/> class.


### PR DESCRIPTION
I was having trouble using Nlog's pattern matching rules with the ServiceStack logging wrapper and ended up here.. http://stackoverflow.com/questions/3947136/problem-matching-specific-nlog-logger-name.

So I've added an option to use Full Type names (default false for backwards compatibility) and changed the internal logging impl to preserve call site information (so that logs are filled up with this "Foo.Bar.Baz.ScheduledTasks.Tasks.CleanDBTablesJob.Execute" instead of this "ServiceStack.Logging.NLogger.NLogLogger.InfoFormat")
