### PR TITLE
Nuget package for log4net v1.2.10 missing due to incorrect nuspec file name

### DIFF
--- a/src/ServiceStack.Logging.Log4Netv1210/ServiceStack.Logging.Log4Netv1210.nuspec
+++ b/src/ServiceStack.Logging.Log4Netv1210/ServiceStack.Logging.Log4Netv1210.nuspec
@@ -16,7 +16,7 @@
     <language>en-US</language>
     <copyright>servicestack.net 2012 and contributors</copyright>
     <dependencies>
-      <dependency id="log4net" version="1.2.10" />
+      <dependency id="log4net" version="[1.2.10]" />
       <dependency id="ServiceStack.Common" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
please refer to this thread and the linked message in particular
https://groups.google.com/d/msg/servicestack/Bbr6UqTH44E/BuH4vMB13XoJ
