### PR TITLE
Catching up ServiceStack.Logging to 3.9.48

### DIFF
--- a/src/ServiceStack.Logging.Elmah/ServiceStack.Logging.Elmah.csproj
+++ b/src/ServiceStack.Logging.Elmah/ServiceStack.Logging.Elmah.csproj
@@ -39,17 +39,17 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Common, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Common, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Common.3.9.44\lib\net35\ServiceStack.Common.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Common.3.9.48\lib\net35\ServiceStack.Common.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Interfaces, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Common.3.9.44\lib\net35\ServiceStack.Interfaces.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Common.3.9.48\lib\net35\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Text, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Text.3.9.44\lib\net35\ServiceStack.Text.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Text.3.9.48\lib\net35\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Web" />

--- a/src/ServiceStack.Logging.Elmah/packages.config
+++ b/src/ServiceStack.Logging.Elmah/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="elmah.corelibrary" version="1.2.2" targetFramework="net35" />
-  <package id="ServiceStack.Common" version="3.9.44" targetFramework="net35" />
-  <package id="ServiceStack.Text" version="3.9.44" targetFramework="net35" />
+  <package id="ServiceStack.Common" version="3.9.48" targetFramework="net35" />
+  <package id="ServiceStack.Text" version="3.9.48" targetFramework="net35" />
 </packages>

--- a/src/ServiceStack.Logging.EnterpriseLibrary5/ServiceStack.Logging.EntLib5.csproj
+++ b/src/ServiceStack.Logging.EnterpriseLibrary5/ServiceStack.Logging.EntLib5.csproj
@@ -57,17 +57,17 @@
     <Reference Include="Microsoft.Practices.Unity.Interception.Configuration, Version=2.1.505.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Unity.Interception.2.1.505.2\lib\NET35\Microsoft.Practices.Unity.Interception.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Common, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Common, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Common.3.9.44\lib\net35\ServiceStack.Common.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Common.3.9.48\lib\net35\ServiceStack.Common.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Interfaces, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Common.3.9.44\lib\net35\ServiceStack.Interfaces.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Common.3.9.48\lib\net35\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Text, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Text.3.9.44\lib\net35\ServiceStack.Text.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Text.3.9.48\lib\net35\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/src/ServiceStack.Logging.EnterpriseLibrary5/packages.config
+++ b/src/ServiceStack.Logging.EnterpriseLibrary5/packages.config
@@ -3,8 +3,8 @@
   <package id="CommonServiceLocator" version="1.0" targetFramework="net35" />
   <package id="EnterpriseLibrary.Common" version="5.0.505.0" targetFramework="net35" />
   <package id="EnterpriseLibrary.Logging" version="5.0.505.1" targetFramework="net35" />
-  <package id="ServiceStack.Common" version="3.9.44" targetFramework="net35" />
-  <package id="ServiceStack.Text" version="3.9.44" targetFramework="net35" />
+  <package id="ServiceStack.Common" version="3.9.48" targetFramework="net35" />
+  <package id="ServiceStack.Text" version="3.9.48" targetFramework="net35" />
   <package id="Unity" version="2.1.505.2" targetFramework="net35" />
   <package id="Unity.Interception" version="2.1.505.2" targetFramework="net35" />
 </packages>

--- a/src/ServiceStack.Logging.EventLog/ServiceStack.Logging.EventLog.csproj
+++ b/src/ServiceStack.Logging.EventLog/ServiceStack.Logging.EventLog.csproj
@@ -62,17 +62,17 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ServiceStack.Common, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Common, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Common.3.9.44\lib\net35\ServiceStack.Common.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Common.3.9.48\lib\net35\ServiceStack.Common.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Interfaces, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Common.3.9.44\lib\net35\ServiceStack.Interfaces.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Common.3.9.48\lib\net35\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Text, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Text.3.9.44\lib\net35\ServiceStack.Text.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Text.3.9.48\lib\net35\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/ServiceStack.Logging.EventLog/packages.config
+++ b/src/ServiceStack.Logging.EventLog/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ServiceStack.Common" version="3.9.44" targetFramework="net35" />
-  <package id="ServiceStack.Text" version="3.9.44" targetFramework="net35" />
+  <package id="ServiceStack.Common" version="3.9.48" targetFramework="net35" />
+  <package id="ServiceStack.Text" version="3.9.48" targetFramework="net35" />
 </packages>

--- a/src/ServiceStack.Logging.Log4Net/ServiceStack.Logging.Log4Net.csproj
+++ b/src/ServiceStack.Logging.Log4Net/ServiceStack.Logging.Log4Net.csproj
@@ -65,17 +65,17 @@
     <Reference Include="log4net, Version=1.2.11.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.0\lib\net35-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Common, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Common, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Common.3.9.44\lib\net35\ServiceStack.Common.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Common.3.9.48\lib\net35\ServiceStack.Common.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Interfaces, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Common.3.9.44\lib\net35\ServiceStack.Interfaces.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Common.3.9.48\lib\net35\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Text, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Text.3.9.44\lib\net35\ServiceStack.Text.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Text.3.9.48\lib\net35\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/ServiceStack.Logging.Log4Net/packages.config
+++ b/src/ServiceStack.Logging.Log4Net/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.0" targetFramework="net35" />
-  <package id="ServiceStack.Common" version="3.9.44" targetFramework="net35" />
-  <package id="ServiceStack.Text" version="3.9.44" targetFramework="net35" />
+  <package id="ServiceStack.Common" version="3.9.48" targetFramework="net35" />
+  <package id="ServiceStack.Text" version="3.9.48" targetFramework="net35" />
 </packages>

--- a/src/ServiceStack.Logging.Log4Netv1210/ServiceStack.Logging.Log4Netv1210.csproj
+++ b/src/ServiceStack.Logging.Log4Netv1210/ServiceStack.Logging.Log4Netv1210.csproj
@@ -65,17 +65,17 @@
     <Reference Include="log4net">
       <HintPath>..\..\lib\log4net.1.2.10.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Common, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Common, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Common.3.9.44\lib\net35\ServiceStack.Common.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Common.3.9.48\lib\net35\ServiceStack.Common.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Interfaces, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Common.3.9.44\lib\net35\ServiceStack.Interfaces.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Common.3.9.48\lib\net35\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Text, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Text.3.9.44\lib\net35\ServiceStack.Text.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Text.3.9.48\lib\net35\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/ServiceStack.Logging.Log4Netv1210/packages.config
+++ b/src/ServiceStack.Logging.Log4Netv1210/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ServiceStack.Common" version="3.9.44" targetFramework="net35" />
-  <package id="ServiceStack.Text" version="3.9.44" targetFramework="net35" />
+  <package id="ServiceStack.Common" version="3.9.48" targetFramework="net35" />
+  <package id="ServiceStack.Text" version="3.9.48" targetFramework="net35" />
 </packages>

--- a/src/ServiceStack.Logging.Log4Netv129/ServiceStack.Logging.Log4Netv129.csproj
+++ b/src/ServiceStack.Logging.Log4Netv129/ServiceStack.Logging.Log4Netv129.csproj
@@ -62,17 +62,17 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ServiceStack.Common, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Common, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Common.3.9.44\lib\net35\ServiceStack.Common.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Common.3.9.48\lib\net35\ServiceStack.Common.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Interfaces, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Common.3.9.44\lib\net35\ServiceStack.Interfaces.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Common.3.9.48\lib\net35\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Text, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Text.3.9.44\lib\net35\ServiceStack.Text.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Text.3.9.48\lib\net35\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/ServiceStack.Logging.Log4Netv129/packages.config
+++ b/src/ServiceStack.Logging.Log4Netv129/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ServiceStack.Common" version="3.9.44" targetFramework="net35" />
-  <package id="ServiceStack.Text" version="3.9.44" targetFramework="net35" />
+  <package id="ServiceStack.Common" version="3.9.48" targetFramework="net35" />
+  <package id="ServiceStack.Text" version="3.9.48" targetFramework="net35" />
 </packages>

--- a/src/ServiceStack.Logging.NLog/ServiceStack.Logging.NLog.csproj
+++ b/src/ServiceStack.Logging.NLog/ServiceStack.Logging.NLog.csproj
@@ -37,17 +37,17 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NLog.2.0.1.2\lib\net35\NLog.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Common, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Common, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Common.3.9.44\lib\net35\ServiceStack.Common.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Common.3.9.48\lib\net35\ServiceStack.Common.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Interfaces, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Common.3.9.44\lib\net35\ServiceStack.Interfaces.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Common.3.9.48\lib\net35\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=3.9.44.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ServiceStack.Text, Version=3.9.48.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ServiceStack.Text.3.9.44\lib\net35\ServiceStack.Text.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Text.3.9.48\lib\net35\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/ServiceStack.Logging.NLog/packages.config
+++ b/src/ServiceStack.Logging.NLog/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NLog" version="2.0.1.2" targetFramework="net35" />
-  <package id="ServiceStack.Common" version="3.9.44" targetFramework="net35" />
-  <package id="ServiceStack.Text" version="3.9.44" targetFramework="net35" />
+  <package id="ServiceStack.Common" version="3.9.48" targetFramework="net35" />
+  <package id="ServiceStack.Text" version="3.9.48" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
Previous NuGet linked to **3.9.44**, which caused build errors in **Mono** when `ServiceStack.*` head version is **3.9.48**.

This pull requests catches up the lagging **3.9.44** NuGet packages to **3.9.48**.

See this problem on StackOverflow:
http://stackoverflow.com/questions/16784739/new-to-c-mono-servicestack-redis-cannot-find-reference/16843995

I think we need some synchronized releases with **_all**_ **ServiceStack** packages; otherwise, we start leaving the **Mono** people behind.
### The problem
#### Steps to reproduce the problem
- `ServiceStack.Logging.NLog` is compiled against **3.9.44** on NuGet
- The head version is of `ServiceStack.*` is **3.9.48**.
1. You download NuGet `ServiceStack` **3.9.48**
2. You download NuGet `ServiceStack.Logging.NLog` which is compiled against **3.9.44**

When building using **xbuild** on **Mono** will produce the following:

```
Errors:

/root/tmp/MyProject/Source/MyProject.sln (default targets) ->
(Build target) ->
/root/tmp/MyProject/Source/MyProject.Server/MyProject.Server.csproj (default targets) ->
/usr/lib/mono/4.0/Microsoft.CSharp.targets (CoreCompile target) ->

        Program.cs(47,83): error CS0234: The type or namespace name `NLogger' does not exist in the namespace `ServiceStack.Logging'. Are you missing an assembly reference?
```
